### PR TITLE
chore: bump version, fix dirname of SDK import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-01-10
+
+### Changed
+
 - Removed the `__sdk.js` developer file from the respoitory.
 - Fixed the types for runAirtableScript.
+- Made the distribution use a relative path for importing the SDK code.
 
 ## [0.0.2] - 2025-01-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-airtable-script",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A jest environment for testing Airtable scripts in extensions and automations",
   "license": "Apache-2.0",
   "author": "",

--- a/src/environment/run-airtable-script.ts
+++ b/src/environment/run-airtable-script.ts
@@ -66,7 +66,7 @@ const runAirtableScript = async ({
     // The path is dynamically rewritten in the build script
     const sdkScriptPath = process.env.JEST_AIRTABLE_TS_DEV
       ? './src/environment/sdk.js'
-      : './sdk.js'
+      : __dirname + '/sdk.js'
     sdkScript = fs.readFileSync(sdkScriptPath, 'utf8').toString()
   }
 


### PR DESCRIPTION
- Fix SDK import in distribution
- Bump version to `0.0.3`