### PR TITLE
Add support for catching errors within main script function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-03-12
+
+### Added
+
+- Handled thrown errors within script code. Errors are now caught and returned in the results object.
+
 ## [0.0.4] - 2025-01-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -241,6 +241,22 @@ it('logs a message', async () => {
 })
 ```
 
+#### Thrown errors
+
+If your script throws a new error to stop execution, you can catch that error in the results object. The error is stored in the `thrownErrors` property of the results object:
+
+```js
+it('throws an error', async () => {
+  const { thrownError } = await runAirtableScript({
+    script: `
+      throw new Error('This is an error')
+    `,
+    base: testBase,
+  })
+  expect(thrownError.message).toEqual('This is an error')
+})
+```
+
 ## Developing locally
 
 The environment variable `JEST_AIRTABLE_TS_DEV` should be set to `true` so that the `runScript` function pulls the compiled SDK mock from the `./src/environment/sdk/__sdk.js` file. This is already set to `true` in the `package.json` file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-airtable-script",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "A jest environment for testing Airtable scripts in extensions and automations",
   "license": "Apache-2.0",
   "author": "",

--- a/test/catch-errors.test.ts
+++ b/test/catch-errors.test.ts
@@ -1,0 +1,52 @@
+describe('Catch errors test', () => {
+  it('sets thrownError to false if none are thrown', async () => {
+    const randomTable = Math.random().toString(36).substring(7)
+    const results = await runAirtableScript({
+      script: `
+      const table = base.getTable('Table ${randomTable}')
+      output.text(table.id)
+    `,
+      base: {
+        base: {
+          tables: [
+            {
+              id: 'tbl1',
+              name: 'Table 1',
+            },
+            {
+              id: `tbl${randomTable}`,
+              name: `Table ${randomTable}`,
+            },
+          ],
+        },
+      },
+    })
+    expect(results.thrownError).toBe(false)
+  })
+
+  it('catches errors thrown in the script', async () => {
+    const randomTable = Math.random().toString(36).substring(7)
+    const results = await runAirtableScript({
+      script: `
+      const table = base.getTable('Table ${randomTable}')
+      throw new Error('This is an error')
+    `,
+      base: {
+        base: {
+          tables: [
+            {
+              id: 'tbl1',
+              name: 'Table 1',
+            },
+            {
+              id: `tbl${randomTable}`,
+              name: `Table ${randomTable}`,
+            },
+          ],
+        },
+      },
+    })
+
+    expect(results.thrownError.message).toBe('This is an error')
+  })
+})


### PR DESCRIPTION
- If a script throws an error, catch it in the `thrownError` result.