### PR TITLE
fix: matched redacted secrets to Airtable editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-05-15
+
+### Fixed
+
+- Changed the redacted value of input secrets to match that in the Airtable editor.
+
 ## [0.2.0] - 2025-05-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-environment-airtable-script",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A jest environment for testing Airtable scripts in extensions and automations",
   "license": "Apache-2.0",
   "author": "",

--- a/src/environment/console-aggregator.ts
+++ b/src/environment/console-aggregator.ts
@@ -3,7 +3,7 @@
  * Airtable seems to just track all the secret values and redact them using a search
  * when outputting the console.
  */
-const SECRET_VALUE_REDACTED: string = '[secret value redacted]'
+const SECRET_VALUE_REDACTED: string = '[secret value is hidden]'
 
 type ConsoleMessage = {
   type: 'log' | 'warn' | 'error'


### PR DESCRIPTION

### Fixed

- Changed the redacted value of input secrets to match that in the Airtable editor.